### PR TITLE
Bugfix/77 session uid overflow

### DIFF
--- a/src/application/exceptions.py
+++ b/src/application/exceptions.py
@@ -23,7 +23,7 @@ class SessionNotFoundError(Exception):
         SessionNotFoundError: Session with UID 12345 not found
     """
     
-    def __init__(self, session_uid: int, message: str = None):
+    def __init__(self, session_uid: str, message: str = None):
         self.session_uid = session_uid
         if message is None:
             message = f"Session with UID {session_uid} not found"

--- a/src/application/use_cases/reconstruct_track.py
+++ b/src/application/use_cases/reconstruct_track.py
@@ -69,7 +69,7 @@ class ReconstructTrackUseCase:
     
     async def execute(
         self,
-        session_uid: int,
+        session_uid: str,
         min_laps: int = 3
     ) -> TrackProfile:
         """Reconstruct track geometry from session telemetry data.

--- a/src/domain/entities/car_setup_snapshot.py
+++ b/src/domain/entities/car_setup_snapshot.py
@@ -20,7 +20,7 @@ class CarSetupSnapshot:
     
     Attributes:
         setup_id (str): Unique identifier for this setup snapshot (UUID).
-        session_uid (int): Session identifier from F1 25 (links to session).
+        session_uid (str): Session identifier from F1 25 (links to session).
         timestamp_ms (int): Session time when snapshot was captured (milliseconds).
         
         front_wing (int): Front wing aero angle (F1 25: m_frontWing).
@@ -86,7 +86,7 @@ class CarSetupSnapshot:
     
     def __init__(
         self,
-        session_uid: int,
+        session_uid: str,
         timestamp_ms: int,
         # Aerodynamics
         front_wing: int,
@@ -271,7 +271,7 @@ class CarSetupSnapshot:
         return self._setup_id
     
     @property
-    def session_uid(self) -> int:
+    def session_uid(self) -> str:
         return self._session_uid
     
     @property

--- a/src/domain/entities/lap_trace.py
+++ b/src/domain/entities/lap_trace.py
@@ -20,7 +20,7 @@ class LapTrace:
     
     Attributes:
         trace_id (str): Unique identifier for this lap trace (UUID).
-        session_uid (int): Session identifier from F1 25.
+        session_uid (str): Session identifier from F1 25.
         lap_number (int): Lap number within the session.
         track_id (Optional[str]): Track identifier from F1 25.
         car_index (int): Player car index from F1 25.
@@ -38,7 +38,7 @@ class LapTrace:
     
     def __init__(
         self,
-        session_uid: int,
+        session_uid: str,
         lap_number: int,
         car_index: int,
         is_valid: bool = True,
@@ -95,7 +95,7 @@ class LapTrace:
         return self._trace_id
     
     @property
-    def session_uid(self) -> int:
+    def session_uid(self) -> str:
         return self._session_uid
     
     @property

--- a/src/domain/interfaces/telemetry_repository.py
+++ b/src/domain/interfaces/telemetry_repository.py
@@ -66,7 +66,7 @@ class ITelemetryRepository(ABC):
         pass
     
     @abstractmethod
-    async def get_latest_lap_trace(self, session_uid: int) -> Optional[LapTrace]:
+    async def get_latest_lap_trace(self, session_uid: str) -> Optional[LapTrace]:
         """Get most recent lap trace for a session.
         
         Returns the lap with the highest lap_number in the specified session.
@@ -83,7 +83,7 @@ class ITelemetryRepository(ABC):
     @abstractmethod
     async def list_lap_traces(
         self,
-        session_uid: int,
+        session_uid: str,
         limit: int = 50,
         offset: int = 0
     ) -> List[LapTrace]:
@@ -130,7 +130,7 @@ class ITelemetryRepository(ABC):
     async def get_fastest_lap_trace(
         self,
         track_id: Optional[str] = None,
-        session_uid: Optional[int] = None
+        session_uid: Optional[str] = None
     ) -> Optional[LapTrace]:
         """Get fastest valid lap trace, optionally filtered by track or session.
         
@@ -206,7 +206,7 @@ class ITelemetryRepository(ABC):
     @abstractmethod
     async def list_setup_snapshots(
         self,
-        session_uid: int,
+        session_uid: str,
         limit: int = 50
     ) -> List[CarSetupSnapshot]:
         """List all setup snapshots captured in a session.
@@ -230,7 +230,7 @@ class ITelemetryRepository(ABC):
     @abstractmethod
     async def save_session(
         self,
-        session_uid: int,
+        session_uid: str,
         track_id: str,
         session_type: int,
         user_id: Optional[str] = None,
@@ -251,7 +251,7 @@ class ITelemetryRepository(ABC):
         pass
     
     @abstractmethod
-    async def get_session(self, session_uid: int) -> Optional[Dict[str, Any]]:
+    async def get_session(self, session_uid: str) -> Optional[Dict[str, Any]]:
         """Retrieve session metadata.
         
         Args:
@@ -259,7 +259,7 @@ class ITelemetryRepository(ABC):
             
         Returns:
             Dictionary with session metadata:
-            - session_uid: int
+            - session_uid: str
             - track_id: str
             - session_type: int
             - started_at: datetime
@@ -290,7 +290,7 @@ class ITelemetryRepository(ABC):
     async def get_latest_session_for_user(
         self,
         user_id: str
-    ) -> Optional[int]:
+    ) -> Optional[str]:
         """Get the most recent session UID for a user.
         
         Args:
@@ -307,7 +307,7 @@ class ITelemetryRepository(ABC):
         self,
         user_id: str,
         track_id: str
-    ) -> Optional[int]:
+    ) -> Optional[str]:
         """Get the most recent session UID for a user on a specific track.
         
         Args:

--- a/src/domain/value_objects/telemetry_sample.py
+++ b/src/domain/value_objects/telemetry_sample.py
@@ -169,9 +169,12 @@ class TelemetrySample:
             )
         
         # Lap distance validation
-        if self.lap_distance < 0:
+        # Note: lap_distance can be slightly negative near start/finish line
+        # F1 game reports negative values briefly when crossing the line
+        # Only reject extreme negative values that indicate data corruption
+        if self.lap_distance < -100.0:
             raise ValueError(
-                f"lap_distance must be non-negative (meters), got {self.lap_distance}"
+                f"lap_distance is invalid (meters), got {self.lap_distance}"
             )
         
         # Lap number validation (must be at least 1)

--- a/src/infrastructure/migrations/001_telemetry_schema.sql
+++ b/src/infrastructure/migrations/001_telemetry_schema.sql
@@ -26,7 +26,8 @@ PRAGMA foreign_keys = ON;
 -- ============================================================================
 CREATE TABLE IF NOT EXISTS sessions (
     -- Primary key: F1 25 session UID from PacketHeader.m_sessionUID
-    session_uid INTEGER PRIMARY KEY NOT NULL,
+    -- TEXT to avoid SQLite INTEGER overflow (F1 UIDs can exceed signed 64-bit)
+    session_uid TEXT PRIMARY KEY NOT NULL,
     
     -- Track identifier from F1 25 (e.g., "monaco", "silverstone")
     track_id TEXT NOT NULL,
@@ -63,7 +64,7 @@ CREATE TABLE IF NOT EXISTS car_setups (
     setup_id TEXT PRIMARY KEY NOT NULL,
     
     -- Foreign key: session this setup was captured in
-    session_uid INTEGER NOT NULL,
+    session_uid TEXT NOT NULL,
     
     -- Session time when snapshot was captured (milliseconds)
     timestamp_ms INTEGER NOT NULL,
@@ -135,7 +136,7 @@ CREATE TABLE IF NOT EXISTS lap_metadata (
     trace_id TEXT PRIMARY KEY NOT NULL,
     
     -- Foreign key: session this lap belongs to
-    session_uid INTEGER NOT NULL,
+    session_uid TEXT NOT NULL,
     
     -- Foreign key: car setup used for this lap (optional)
     -- NULL if no setup snapshot associated with this lap

--- a/src/infrastructure/persistence/sqlite_telemetry_repository.py
+++ b/src/infrastructure/persistence/sqlite_telemetry_repository.py
@@ -192,7 +192,7 @@ class SQLiteTelemetryRepository(ITelemetryRepository):
             
             return lap_trace
     
-    async def get_latest_lap_trace(self, session_uid: int) -> Optional[LapTrace]:
+    async def get_latest_lap_trace(self, session_uid: str) -> Optional[LapTrace]:
         """Get most recent lap trace for a session.
         
         Args:
@@ -220,7 +220,7 @@ class SQLiteTelemetryRepository(ITelemetryRepository):
     
     async def list_lap_traces(
         self,
-        session_uid: int,
+        session_uid: str,
         limit: int = 50,
         offset: int = 0
     ) -> List[LapTrace]:
@@ -304,7 +304,7 @@ class SQLiteTelemetryRepository(ITelemetryRepository):
     async def get_fastest_lap_trace(
         self,
         track_id: Optional[str] = None,
-        session_uid: Optional[int] = None
+        session_uid: Optional[str] = None
     ) -> Optional[LapTrace]:
         """Get fastest valid lap trace, optionally filtered.
         
@@ -490,7 +490,7 @@ class SQLiteTelemetryRepository(ITelemetryRepository):
     
     async def list_setup_snapshots(
         self,
-        session_uid: int,
+        session_uid: str,
         limit: int = 50
     ) -> List[CarSetupSnapshot]:
         """List all setup snapshots captured in a session.
@@ -522,7 +522,7 @@ class SQLiteTelemetryRepository(ITelemetryRepository):
     
     async def save_session(
         self,
-        session_uid: int,
+        session_uid: str,
         track_id: str,
         session_type: int,
         user_id: Optional[str] = None,
@@ -550,7 +550,7 @@ class SQLiteTelemetryRepository(ITelemetryRepository):
             
             await db.commit()
     
-    async def get_session(self, session_uid: int) -> Optional[Dict[str, Any]]:
+    async def get_session(self, session_uid: str) -> Optional[Dict[str, Any]]:
         """Retrieve session metadata.
         
         Args:
@@ -640,7 +640,7 @@ class SQLiteTelemetryRepository(ITelemetryRepository):
     async def get_latest_session_for_user(
         self,
         user_id: str
-    ) -> Optional[int]:
+    ) -> Optional[str]:
         """Get the most recent session UID for a user.
         
         Args:
@@ -670,7 +670,7 @@ class SQLiteTelemetryRepository(ITelemetryRepository):
         self,
         user_id: str,
         track_id: str
-    ) -> Optional[int]:
+    ) -> Optional[str]:
         """Get the most recent session UID for a user on a specific track.
         
         Args:

--- a/src/presentation/api/telemetry_api.py
+++ b/src/presentation/api/telemetry_api.py
@@ -28,7 +28,8 @@ class TelemetryAPI:
         self.submit_use_case = SubmitLapTimeUseCase(lap_time_repository, driver_rating_repository)
         self.update_elo_use_case = UpdateEloRatingsUseCase(driver_rating_repository, lap_time_repository)
         self.discord_bot = discord_bot  # Reference to Discord bot for user lookup
-        self.app = web.Application()
+        # Increase max request size to 10MB for telemetry traces (300-500 samples per lap)
+        self.app = web.Application(client_max_size=10*1024*1024)
         self.runner: Optional[web.AppRunner] = None
         self.site: Optional[web.TCPSite] = None
         

--- a/src/presentation/api/telemetry_api.py
+++ b/src/presentation/api/telemetry_api.py
@@ -242,7 +242,7 @@ class TelemetryAPI:
             
             # Register session
             await self.telemetry_repository.save_session(
-                session_uid=int(session_uid),
+                session_uid=str(session_uid),
                 track_id=track_id,
                 session_type=int(session_type),
                 user_id=user_id
@@ -300,7 +300,7 @@ class TelemetryAPI:
             
             # Create LapTrace entity
             lap_trace = LapTrace(
-                session_uid=int(session_uid),
+                session_uid=str(session_uid),
                 lap_number=int(lap_number),
                 car_index=int(car_index),
                 is_valid=bool(is_valid),

--- a/src/presentation/api/telemetry_api.py
+++ b/src/presentation/api/telemetry_api.py
@@ -299,17 +299,17 @@ class TelemetryAPI:
             from src.domain.entities.lap_trace import LapTrace
             from src.domain.value_objects.telemetry_sample import TelemetrySample
             
-            # Create LapTrace entity
+            # Create LapTrace entity (without lap_time_ms so it's not marked complete yet)
             lap_trace = LapTrace(
                 session_uid=str(session_uid),
                 lap_number=int(lap_number),
                 car_index=int(car_index),
                 is_valid=bool(is_valid),
                 track_id=track_id,
-                lap_time_ms=int(lap_time_ms)
+                lap_time_ms=None  # Don't set lap_time yet - samples must be added first
             )
             
-            # Add telemetry samples
+            # Add telemetry samples (must be done before marking complete)
             for sample_data in samples:
                 try:
                     sample = TelemetrySample(
@@ -338,7 +338,7 @@ class TelemetryAPI:
                     self.logger.warning(f"Skipping invalid sample: {e}")
                     continue
             
-            # Mark lap as complete
+            # Now mark lap as complete with final time
             lap_trace.mark_complete(int(lap_time_ms))
             
             # Save to telemetry database

--- a/udp-listener-package/telemetry_listener_v3.py
+++ b/udp-listener-package/telemetry_listener_v3.py
@@ -387,12 +387,11 @@ class F1TelemetryListenerV3:
         # Store latest lap data
         self.latest_lap_data = lap_data
         
-        # Establish baseline (skip laps driven before listener started)
-        if not self.baseline_lap_established and lap_time_ms > 0:
-            print(f"🔄 Baseline established: Lap {current_lap_num} (existing lap ignored)")
+        # Establish baseline on first lap data (start tracking immediately)
+        if not self.baseline_lap_established:
+            print(f"🔄 Baseline established: Starting from Lap {current_lap_num}")
             self.baseline_lap_established = True
-            self.current_lap_number = current_lap_num
-            return
+            self.current_lap_number = current_lap_num - 1  # Set to previous lap so next lap triggers new lap logic
         
         # Track lap number changes (new lap started)
         if current_lap_num != self.current_lap_number:

--- a/udp-listener-package/telemetry_listener_v3.py
+++ b/udp-listener-package/telemetry_listener_v3.py
@@ -83,7 +83,7 @@ class SessionInfo:
     """Session information from F1 2025."""
     session_type: int
     track_id: int
-    session_uid: int
+    session_uid: str
     is_time_trial: bool = False
     track_name: str = "Unknown"
 
@@ -91,7 +91,7 @@ class SessionInfo:
 class LapTraceBuilder:
     """Builds a complete lap trace by collecting telemetry samples."""
     
-    def __init__(self, session_uid: int, lap_number: int, car_index: int, track_id: str):
+    def __init__(self, session_uid: str, lap_number: int, car_index: int, track_id: str):
         self.session_uid = session_uid
         self.lap_number = lap_number
         self.car_index = car_index
@@ -290,13 +290,16 @@ class F1TelemetryListenerV3:
             track_name = TRACK_MAPPING.get(track_id, f"track_{track_id}")
             is_time_trial = session_type == SESSION_TYPE_TIME_TRIAL
             
+            # Convert session_uid to string to avoid SQLite INTEGER overflow
+            session_uid_str = str(session_uid)
+            
             # Detect new session
             if is_time_trial and (not self.session_info or 
-                                 self.session_info.session_uid != session_uid):
+                                 self.session_info.session_uid != session_uid_str):
                 self.session_info = SessionInfo(
                     session_type=session_type,
                     track_id=track_id,
-                    session_uid=session_uid,
+                    session_uid=session_uid_str,
                     is_time_trial=True,
                     track_name=track_name
                 )


### PR DESCRIPTION
This pull request standardizes the type of `session_uid` throughout the codebase, changing it from `int` to `str` to prevent issues with integer overflow and to better align with the nature of F1 session UIDs. The change affects domain entities, repository interfaces and implementations, database schema, and API handling. Additionally, there are minor improvements to telemetry sample validation and API request size limits.

**Session UID type migration**

* Changed all references to `session_uid` from `int` to `str` in domain entities such as `CarSetupSnapshot` and `LapTrace`, including constructors and property methods. [[1]](diffhunk://#diff-33659926657255dc742107593f8486498c028b5bdb3a62a787d04c84f763ff65L23-R23) [[2]](diffhunk://#diff-33659926657255dc742107593f8486498c028b5bdb3a62a787d04c84f763ff65L89-R89) [[3]](diffhunk://#diff-33659926657255dc742107593f8486498c028b5bdb3a62a787d04c84f763ff65L274-R274) [[4]](diffhunk://#diff-441bc554dc6da9ca8ecc78e877ab15934fcf492f1b9e2a42a29dc67e51e9635dL23-R23) [[5]](diffhunk://#diff-441bc554dc6da9ca8ecc78e877ab15934fcf492f1b9e2a42a29dc67e51e9635dL41-R41) [[6]](diffhunk://#diff-441bc554dc6da9ca8ecc78e877ab15934fcf492f1b9e2a42a29dc67e51e9635dL98-R98)
* Updated repository interface methods and their implementations to use `str` for `session_uid`, including methods for saving, retrieving, and listing sessions, lap traces, and setup snapshots. [[1]](diffhunk://#diff-165f14c207e506764e51e5e83d584b7080f63159c4e04a2c9c2eb25716b417b0L69-R69) [[2]](diffhunk://#diff-165f14c207e506764e51e5e83d584b7080f63159c4e04a2c9c2eb25716b417b0L86-R86) [[3]](diffhunk://#diff-165f14c207e506764e51e5e83d584b7080f63159c4e04a2c9c2eb25716b417b0L133-R133) [[4]](diffhunk://#diff-165f14c207e506764e51e5e83d584b7080f63159c4e04a2c9c2eb25716b417b0L209-R209) [[5]](diffhunk://#diff-165f14c207e506764e51e5e83d584b7080f63159c4e04a2c9c2eb25716b417b0L233-R233) [[6]](diffhunk://#diff-165f14c207e506764e51e5e83d584b7080f63159c4e04a2c9c2eb25716b417b0L254-R262) [[7]](diffhunk://#diff-165f14c207e506764e51e5e83d584b7080f63159c4e04a2c9c2eb25716b417b0L293-R293) [[8]](diffhunk://#diff-165f14c207e506764e51e5e83d584b7080f63159c4e04a2c9c2eb25716b417b0L310-R310) [[9]](diffhunk://#diff-27c0bb14ae5d189dd501e9716bafcd3dba28a7a23d31e948abb43d6d91c74b22L195-R195) [[10]](diffhunk://#diff-27c0bb14ae5d189dd501e9716bafcd3dba28a7a23d31e948abb43d6d91c74b22L223-R223) [[11]](diffhunk://#diff-27c0bb14ae5d189dd501e9716bafcd3dba28a7a23d31e948abb43d6d91c74b22L307-R307) [[12]](diffhunk://#diff-27c0bb14ae5d189dd501e9716bafcd3dba28a7a23d31e948abb43d6d91c74b22L493-R493) [[13]](diffhunk://#diff-27c0bb14ae5d189dd501e9716bafcd3dba28a7a23d31e948abb43d6d91c74b22L525-R525) [[14]](diffhunk://#diff-27c0bb14ae5d189dd501e9716bafcd3dba28a7a23d31e948abb43d6d91c74b22L553-R553) [[15]](diffhunk://#diff-27c0bb14ae5d189dd501e9716bafcd3dba28a7a23d31e948abb43d6d91c74b22L643-R643) [[16]](diffhunk://#diff-27c0bb14ae5d189dd501e9716bafcd3dba28a7a23d31e948abb43d6d91c74b22L673-R673)
* Migrated the database schema in `001_telemetry_schema.sql` to use `TEXT` for `session_uid` columns instead of `INTEGER`, preventing overflow and ensuring consistency. [[1]](diffhunk://#diff-83e96672566bd3b32835e5daa9705f0232bc23d65d3c3f7da33b5ceb0d783e64L29-R30) [[2]](diffhunk://#diff-83e96672566bd3b32835e5daa9705f0232bc23d65d3c3f7da33b5ceb0d783e64L66-R67) [[3]](diffhunk://#diff-83e96672566bd3b32835e5daa9705f0232bc23d65d3c3f7da33b5ceb0d783e64L138-R139)
* Updated API endpoints and request handling to treat `session_uid` as a string, including conversion and validation steps. [[1]](diffhunk://#diff-7d1eca1b4b9ef0c8d291377560df721b37d5e268c7659c88b0d21d7bcf40c641L245-R246) [[2]](diffhunk://#diff-7d1eca1b4b9ef0c8d291377560df721b37d5e268c7659c88b0d21d7bcf40c641L301-R312)
* Refactored UDP listener code to use `str` for session UIDs and ensure compatibility with upstream changes.

**Telemetry validation and API improvements**

* Improved lap distance validation logic in `TelemetrySample` to allow small negative values near the start/finish line, only rejecting extreme negatives indicating corruption.
* Increased maximum request size for the web API to 10MB to accommodate large telemetry traces.
* Clarified comments and logic in lap trace submission to ensure lap completion and sample addition are handled in the correct order. [[1]](diffhunk://#diff-7d1eca1b4b9ef0c8d291377560df721b37d5e268c7659c88b0d21d7bcf40c641L301-R312) [[2]](diffhunk://#diff-7d1eca1b4b9ef0c8d291377560df721b37d5e268c7659c88b0d21d7bcf40c641L340-R341)